### PR TITLE
Update KemonopartyParser.js

### DIFF
--- a/plugin/js/parsers/KemonopartyParser.js
+++ b/plugin/js/parsers/KemonopartyParser.js
@@ -82,7 +82,7 @@ class KemonopartyParser extends Parser {
 
     async getLastPageOffset(dom, urlbuilder) {
         try {
-            let link = [...dom.querySelectorAll("#paginator-top a")].pop();
+            let link = [...dom.querySelectorAll("#paginator-top a")].map(item => parseInt(new URL(item?.href)?.searchParams?.get("o"))).filter(item => item >= 0).sort((a, b) => a - b);
             let offset = new URL(link?.href)?.searchParams?.get("o");
             return offset
                 ? parseInt(offset)


### PR DESCRIPTION
Fixed Kemonoparty paging to get the last page on screen; former pop logic now only gets 'next' button.

This code was tested/pushed from my cellphone; holding back on the merge until the code can be directly tested on PC.